### PR TITLE
Support for signed URLs

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -11,28 +11,75 @@ function baseurl() {
 	return get_option('imgproxy_url');
 }
 
+function signing_key()
+{
+	if (defined('IMGPROXY_KEY')) {
+		return IMGPROXY_KEY;
+	}
+
+	return get_option('imgproxy_key');
+}
+
+function signing_salt()
+{
+	if (defined('IMGPROXY_SALT')) {
+		return IMGPROXY_SALT;
+	}
+
+	return get_option('imgproxy_salt');
+}
+
 // Add the custom field to the Media Settings screen.
 function imgproxy_settings_field() {
-    $imgproxy_url = baseurl();
-    ?>
+	$imgproxy_url = baseurl();
+	$imgproxy_key = signing_key();
+	$imgproxy_salt = signing_salt();
+
+	?>
 		<input type="url" id="imgproxy_url" name="imgproxy_url" placeholder="https://imgproxy.example.com" value="<?php echo esc_attr($imgproxy_url); ?>" class="regular-text" <?php disabled( defined( 'IMGPROXY_URL' ) ); ?>>
 		<p class="description">Enter the base URL of your imgproxy service</p>
-    <?php
+
+		<input type="text" id="imgproxy_key" name="imgproxy_key" placeholder="key" value="<?php echo esc_attr($imgproxy_key); ?>" class="regular-text" <?php disabled(defined('IMGPROXY_KEY')); ?>>
+		<p class="description">Enter the signing key. Signing will be disabled if left empty</p>
+
+		<input type="password" id="imgproxy_salt" name="imgproxy_salt" placeholder="salt" value="<?php echo esc_attr($imgproxy_salt); ?>" class="regular-text" <?php disabled(defined('IMGPROXY_SALT')); ?>>
+		<p class="description">Enter the signing salt. Signing will be disabled if left empty</p>
+	<?php
 }
 
 function imgproxy_settings_page() {
-    add_settings_section('imgproxy_section', 'Imgproxy Settings', '', 'media');
-    add_settings_field('imgproxy_url', 'Imgproxy URL', 'Imgproxy\imgproxy_settings_field', 'media', 'imgproxy_section');
-    register_setting('media', 'imgproxy_url');
+	add_settings_section('imgproxy_section', 'Imgproxy Settings', '', 'media');
+	add_settings_field('imgproxy_url', 'Imgproxy URL', 'Imgproxy\imgproxy_settings_field', 'media', 'imgproxy_section');
+	register_setting('media', 'imgproxy_url');
+	register_setting('media', 'imgproxy_key');
+	register_setting('media', 'imgproxy_salt');
 }
 
 add_action('admin_init', 'Imgproxy\imgproxy_settings_page');
 
 // Save the imgproxy URL value.
 function save_imgproxy_url() {
-    if (isset($_POST['imgproxy_url'])) {
-        update_option('imgproxy_url', sanitize_text_field($_POST['imgproxy_url']));
-    }
+	if (isset($_POST['imgproxy_url'])) {
+		update_option('imgproxy_url', sanitize_text_field($_POST['imgproxy_url']));
+	}
+}
+
+// Save the imgproxy signing key
+function save_imgproxy_key()
+{
+	if (isset($_POST['imgproxy_key'])) {
+		update_option('imgproxy_key', sanitize_text_field($_POST['imgproxy_key']));
+	}
+}
+
+// Save the imgproxy signing salt
+function save_imgproxy_salt()
+{
+	if (isset($_POST['imgproxy_salt'])) {
+		update_option('imgproxy_salt', sanitize_text_field($_POST['imgproxy_salt']));
+	}
 }
 
 add_action('admin_init', 'Imgproxy\save_imgproxy_url');
+add_action('admin_init', 'Imgproxy\save_imgproxy_key');
+add_action('admin_init', 'Imgproxy\save_imgproxy_salt');

--- a/class-imgproxy.php
+++ b/class-imgproxy.php
@@ -8,11 +8,17 @@ class Imgproxy {
 	 * Constructor
 	 *
 	 * @param string $base_url The base URL of the imgproxy server
+	 * @param string $signing_key The signing key of the imgproxy server
+	 * @param string $signing_salt The signing salt of the imgproxy server
 	 */
 	private $base_url;
+	private $signing_key;
+	private $signing_salt;
 
-	function __construct($base_url) {
+	function __construct($base_url, $signing_key, $signing_salt) {
 		$this->base_url = $base_url;
+		$this->signing_key = $signing_key;
+		$this->signing_salt = $signing_salt;
 	}
 
 	function is_imgproxy_url($url) {
@@ -24,6 +30,6 @@ class Imgproxy {
 	}
 
 	function image($image_url, $params = []) {
-		return new ImgproxyImage($this->base_url, $image_url, $params);
+		return new ImgproxyImage($this->base_url, $this->signing_key, $this->signing_salt, $image_url, $params);
 	}
 }

--- a/imgproxy.php
+++ b/imgproxy.php
@@ -280,5 +280,8 @@ function get_srcset_threshold() {
 
 function imgproxy() {
 	$url = baseurl();
-	return new Imgproxy($url);
+	$key = signing_key();
+	$salt = signing_salt();
+
+	return new Imgproxy($url, $key, $salt);
 }


### PR DESCRIPTION
After using the plugin unsigned for some time, the lack of URL signatures felt noticeable to me.

In short, the following changes were made:

- Added options `imgproxy_key` and `imgproxy_salt`
- Added fields for both options in the settings
- Added both options to `Imgproxy` and `ImgproxyImage`
- Modified `ImgproxyImage.url()` to use `ImgproxyImage.get_path_signature()` for URL signing
- Disabled signing with a fallback to `i` instead of a signature if either key or salt is `null` or an empty string

This feature was tested on my WordPress 6.8.1 website, both with and without a signature.

I'm new to WordPress plugins and PHP in general, so I'm sure that some things could have been done better.
Unfortunately, I do not have enough knowledge to improve this feature much further now :(